### PR TITLE
Fix type definition of initContracts params

### DIFF
--- a/src/browser/components/Runner/index.tsx
+++ b/src/browser/components/Runner/index.tsx
@@ -153,7 +153,7 @@ class Runner extends React.Component<Props> {
 
 const mapDispatchToProps = (dispatch: Dispatch) => ({
   initBlockchain: () => dispatch(bcActions.init()),
-  initContracts: (name: string, code: string) => dispatch(contractActions.init()),
+  initContracts: (name?: string, code?: string) => dispatch(contractActions.init()),
   deployContract: (
     code: string,
     init: KVPair[],


### PR DESCRIPTION
This PR fixes TS compilation error: `Argument of type 'typeof Runner' is not assignable to parameter of type`

`initContracts` has this params definition: `initContracts: (name: string, code: string)` and it's real usage is `this.props.initContracts();`. Therefore, Type Definition should allow optional.

the details of error message:
```
Failed to compile.

/Users/noel/savant-ide/src/browser/components/Runner/index.tsx
(205,3): Argument of type 'typeof Runner' is not assignable to parameter of type 'ComponentType<Matching<({ active: Contract; accounts: { [address: string]: Account; }; files: { [key: string]: ContractSrcFile; }; deployedContracts: { [address: string]: Contract; }; isDeployingContract: boolean; isCallingTransition: boolean; } & { ...; }) | ({ ...; } & { ...; }), Props>>'.
  Type 'typeof Runner' is not assignable to type 'ComponentClass<Matching<({ active: Contract; accounts: { [address: string]: Account; }; files: { [key: string]: ContractSrcFile; }; deployedContracts: { [address: string]: Contract; }; isDeployingContract: boolean; isCallingTransition: boolean; } & { ...; }) | ({ ...; } & { ...; }), Props>, any>'.
    Types of parameters 'props' and 'props' are incompatible.
      Type 'Matching<({ active: Contract; accounts: { [address: string]: Account; }; files: { [key: string]: ContractSrcFile; }; deployedContracts: { [address: string]: Contract; }; isDeployingContract: boolean; isCallingTransition: boolean; } & { ...; }) | ({ ...; } & { ...; }), Props>' is not assignable to type 'Readonly<Props>'.
        Types of property 'initContracts' are incompatible.
          Type '(name: string, code: string) => { type: ContractActionTypes.INIT; }' is not assignable to type '() => { type: ContractActionTypes.INIT; }'.
```