### PR TITLE
Use setState callback

### DIFF
--- a/src/browser/components/Navigator/File.tsx
+++ b/src/browser/components/Navigator/File.tsx
@@ -79,14 +79,13 @@ class File extends React.Component<Props, State> {
   }
 
   setRenaming = () => {
-    this.setState({ isRenaming: true });
-
-    setTimeout(() => {
+    const setTextNodeEditable = () => {
       if (this.textNode.current) {
         this.textNode.current.contentEditable = 'true';
         this.textNode.current.focus();
       }
-    });
+    };
+    this.setState({ isRenaming: true }, setTextNodeEditable);
   };
 
   handleChange = (e: React.SyntheticEvent<HTMLParagraphElement>, text: string) => {


### PR DESCRIPTION
This PR replace `setTimeout` with React `setState callback`. I thought using setState callback is a nicer way for handling state changes.

For details:
setState() enqueues changes to the component state and tells React that this component and its children need to be re-rendered with the updated state. This is the primary method you use to update the user interface in response to event handlers and server responses.

Think of setState() as a request rather than an immediate command to update the component. For better perceived performance, React may delay it, and then update several components in a single pass. React does not guarantee that the state changes are applied immediately.

setState() does not always immediately update the component. It may batch or defer the update until later. This makes reading this.state right after calling setState() a potential pitfall. Instead, use componentDidUpdate or a setState callback (setState(updater, callback)), either of which are guaranteed to fire after the update has been applied. If you need to set the state based on the previous state, read about the updater argument below.

[source: https://reactjs.org/docs/react-component.html#setstate]