### PR TITLE
Change clone path for scilla

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 endif
 
 scilla-src:
-	git clone git@github.com:Zilliqa/scilla
+	git clone https://github.com/Zilliqa/scilla.git
 	git -C scilla fetch --all
 	git -C scilla checkout $(SCILLA_BRANCH)
 	git -C scilla pull


### PR DESCRIPTION
Set HTTPS method by default instead of SSH