### PR TITLE
Adjusted the git clone for scilla

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ else
 endif
 
 scilla-src:
-	git clone git@github.com:Zilliqa/scilla
+	git clone https://github.com/Zilliqa/scilla
 	git -C scilla fetch --all
 	git -C scilla checkout $(SCILLA_BRANCH)
 	git -C scilla pull


### PR DESCRIPTION
Using git convention to clone other accounts, removed git convention to clone from your own.

I had cloned the Zilliqa/savant-ide and ran make. When it gets to cloning scilla it chokes and complains that the public keys are not correct. When I investigated it, I found that the https url works and that git@github.com does not. I can use the git@github.com when cloning my own repos.