### PR TITLE
fix(cmd): add back gaslimit with validation

### DIFF
--- a/src/server/util/cmd.ts
+++ b/src/server/util/cmd.ts
@@ -63,6 +63,8 @@ export const runner = async (opts: RunOpt) => {
       init,
       '-iblockchain',
       blockchain,
+      '-gaslimit',
+      parseInt(gaslimit, 10).toString(),
     ];
 
     if (optional.state) {


### PR DESCRIPTION
Add back the missing `gaslimit` flag, and attempts `parseInt` as validation.