### PR TITLE
Fix typo in GPL header

### DIFF
--- a/scripts/prepend_license.sh
+++ b/scripts/prepend_license.sh
@@ -4,7 +4,7 @@ set -e
 
 BANNER='/**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software
@@ -27,7 +27,7 @@ quoteSubst() {
 }
 
 hasBanner() {
-  if grep -Fxq ' * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.' "$1"
+  if grep -Fxq ' * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.' "$1"
   then
     echo 0
   else

--- a/src/browser/App.tsx
+++ b/src/browser/App.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Editor/Controls.tsx
+++ b/src/browser/components/Editor/Controls.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Editor/EventAlerts.tsx
+++ b/src/browser/components/Editor/EventAlerts.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Editor/EventDialog.tsx
+++ b/src/browser/components/Editor/EventDialog.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Editor/Notification.tsx
+++ b/src/browser/components/Editor/Notification.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Editor/Settings.tsx
+++ b/src/browser/components/Editor/Settings.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Editor/StatusLine.tsx
+++ b/src/browser/components/Editor/StatusLine.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Editor/index.tsx
+++ b/src/browser/components/Editor/index.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Footer.tsx
+++ b/src/browser/components/Footer.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Form/InputWrapper.tsx
+++ b/src/browser/components/Form/InputWrapper.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Form/Select.tsx
+++ b/src/browser/components/Form/Select.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Form/TxParams.tsx
+++ b/src/browser/components/Form/TxParams.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Loader.tsx
+++ b/src/browser/components/Loader.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Navigator/File.tsx
+++ b/src/browser/components/Navigator/File.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Navigator/Menu.tsx
+++ b/src/browser/components/Navigator/Menu.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Navigator/index.tsx
+++ b/src/browser/components/Navigator/index.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Placeholder.tsx
+++ b/src/browser/components/Placeholder.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/Call.tsx
+++ b/src/browser/components/Runner/Call.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/Collapsible.tsx
+++ b/src/browser/components/Runner/Collapsible.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/Deploy.tsx
+++ b/src/browser/components/Runner/Deploy.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/InitForm.tsx
+++ b/src/browser/components/Runner/InitForm.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/Nav.tsx
+++ b/src/browser/components/Runner/Nav.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/State.tsx
+++ b/src/browser/components/Runner/State.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/TransitionForm.tsx
+++ b/src/browser/components/Runner/TransitionForm.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Runner/index.tsx
+++ b/src/browser/components/Runner/index.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/Status.tsx
+++ b/src/browser/components/Status.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/components/types.ts
+++ b/src/browser/components/types.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/contracts/index.ts
+++ b/src/browser/contracts/index.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/database/accounts.ts
+++ b/src/browser/database/accounts.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/database/contracts.ts
+++ b/src/browser/database/contracts.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/database/fs.ts
+++ b/src/browser/database/fs.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/database/types.ts
+++ b/src/browser/database/types.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/registerServiceWorker.ts
+++ b/src/browser/registerServiceWorker.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store.ts
+++ b/src/browser/store.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/blockchain/actions.ts
+++ b/src/browser/store/blockchain/actions.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/blockchain/reducer.ts
+++ b/src/browser/store/blockchain/reducer.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/blockchain/saga.ts
+++ b/src/browser/store/blockchain/saga.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/blockchain/types.ts
+++ b/src/browser/store/blockchain/types.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/contract/actions.ts
+++ b/src/browser/store/contract/actions.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/contract/reducer.ts
+++ b/src/browser/store/contract/reducer.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/contract/saga.ts
+++ b/src/browser/store/contract/saga.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/contract/types.ts
+++ b/src/browser/store/contract/types.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/fs/actions.ts
+++ b/src/browser/store/fs/actions.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/fs/reducer.ts
+++ b/src/browser/store/fs/reducer.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/fs/saga.ts
+++ b/src/browser/store/fs/saga.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/fs/types.ts
+++ b/src/browser/store/fs/types.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/store/index.ts
+++ b/src/browser/store/index.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/typings/assets.ts
+++ b/src/browser/typings/assets.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/typings/bn.d.ts
+++ b/src/browser/typings/bn.d.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/__tests__/encoding.spec.ts
+++ b/src/browser/util/__tests__/encoding.spec.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/api.ts
+++ b/src/browser/util/api.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/encoding.ts
+++ b/src/browser/util/encoding.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/form.ts
+++ b/src/browser/util/form.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/parser.d.ts
+++ b/src/browser/util/parser.d.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/storage.ts
+++ b/src/browser/util/storage.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/types.ts
+++ b/src/browser/util/types.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/browser/util/validation.ts
+++ b/src/browser/util/validation.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/constants.ts
+++ b/src/server/constants.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/handlers/check.ts
+++ b/src/server/handlers/check.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/handlers/run.ts
+++ b/src/server/handlers/run.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/util/cmd.ts
+++ b/src/server/util/cmd.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/util/fs.ts
+++ b/src/server/util/fs.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software

--- a/src/server/util/index.ts
+++ b/src/server/util/index.ts
@@ -1,6 +1,6 @@
 /**
  * This file is part of savant-ide.
- * Copyright (c) 2018 - present Zilliqa Research Pvt. Ltd.
+ * Copyright (c) 2018 - present Zilliqa Research Pte. Ltd.
  *
  * savant-ide is free software: you can redistribute it and/or modify it under the
  * terms of the GNU General Public License as published by the Free Software


### PR DESCRIPTION
**Description**
This PR fixes typo as the following: 
`Zilliqa Research Pvt. Ltd` -> `Zilliqa Research Pte. Ltd` 