### PR TITLE
fix(api): pin Scilla version to v0.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zilliqa/scilla:latest
+FROM zilliqa/scilla:v0.2.0
 
 EXPOSE 8080
 # PM2 default health check endpoint is at host:9615/


### PR DESCRIPTION
Pin the Scilla version used to v0.2.0