### PR TITLE
fix: change `name` to `vname`

### DIFF
--- a/src/browser/components/Runner/Call.tsx
+++ b/src/browser/components/Runner/Call.tsx
@@ -108,10 +108,11 @@ export default class CallTab extends React.Component<Props, State> {
     const { selectedContract } = this.state;
 
     const abi = deployedContracts[selectedContract].abi;
+    console.log('ABI: ', JSON.stringify(abi, null, 4));
 
     if (abi && abi.transitions.length > 0) {
       return abi.transitions.map((transition) => {
-        return { key: transition.name, value: transition.name };
+        return { key: transition.vname, value: transition.vname };
       });
     }
 
@@ -123,7 +124,7 @@ export default class CallTab extends React.Component<Props, State> {
 
     return Object.keys(deployedContracts).map((address) => {
       const contract = deployedContracts[address];
-      const key = `0x${address.toUpperCase()} (${(contract.abi && contract.abi.name) || ''})`;
+      const key = `0x${address.toUpperCase()} (${(contract.abi && contract.abi.vname) || ''})`;
       const value = address;
       return { key, value };
     });
@@ -172,7 +173,7 @@ export default class CallTab extends React.Component<Props, State> {
         {abi && (
           <React.Fragment>
             <Select
-              placeholder={`Select a transition for ${abi.name}`}
+              placeholder={`Select a transition for ${abi.vname}`}
               items={this.getTransitionOptions()}
               value={selectedTransition}
               onChange={this.onSelectTransition}
@@ -185,7 +186,7 @@ export default class CallTab extends React.Component<Props, State> {
                   handleReset={this.reset}
                   handleSubmit={this.onCallTransition}
                   result={result}
-                  {...find((t) => t.name === selectedTransition, abi.transitions) as Transition}
+                  {...find((t) => t.vname === selectedTransition, abi.transitions) as Transition}
                 />
               )}
           </React.Fragment>

--- a/src/browser/components/Runner/Call.tsx
+++ b/src/browser/components/Runner/Call.tsx
@@ -108,7 +108,6 @@ export default class CallTab extends React.Component<Props, State> {
     const { selectedContract } = this.state;
 
     const abi = deployedContracts[selectedContract].abi;
-    console.log('ABI: ', JSON.stringify(abi, null, 4));
 
     if (abi && abi.transitions.length > 0) {
       return abi.transitions.map((transition) => {

--- a/src/browser/components/Runner/Deploy.tsx
+++ b/src/browser/components/Runner/Deploy.tsx
@@ -204,7 +204,7 @@ export default class DeployTab extends React.Component<Props, State> {
         />
         {activeAccount && abi ? (
           <InitForm
-            key={abi.name}
+            key={abi.vname}
             handleReset={this.reset}
             handleSubmit={this.onDeploy}
             isDeploying={this.props.isDeploying}

--- a/src/browser/components/Runner/TransitionForm.tsx
+++ b/src/browser/components/Runner/TransitionForm.tsx
@@ -107,7 +107,7 @@ export default class TransitionForm extends React.Component<Props, State> {
       return;
     }
 
-    this.props.handleSubmit(this.props.name, params, msg);
+    this.props.handleSubmit(this.props.vname, params, msg);
   };
 
   handleParamsChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
@@ -183,7 +183,7 @@ export default class TransitionForm extends React.Component<Props, State> {
       return (
         <Status>
           <Typography variant="body2" align="left">
-            {`${this.props.name} at 0x${result.address.toUpperCase()} was successfully called.`}
+            {`${this.props.vname} at 0x${result.address.toUpperCase()} was successfully called.`}
           </Typography>
           <Typography variant="body2" align="left" style={{ whiteSpace: 'pre' }}>
             {`Gas used: ${result.gasUsed}\nGas price: ${
@@ -207,7 +207,7 @@ export default class TransitionForm extends React.Component<Props, State> {
       return (
         <Status>
           <Typography color="error" variant="body2" style={{ whiteSpace: 'pre-line' }}>
-            {`The call to transition ${this.props.name} failed. The following error occured:
+            {`The call to transition ${this.props.vname} failed. The following error occured:
 
               ${result.error.response ? formatError(result.error.response.message) : result.error}
 
@@ -252,12 +252,12 @@ export default class TransitionForm extends React.Component<Props, State> {
 
                 return (
                   field && (
-                    <InputWrapper key={name} error={field.error}>
-                      <InputLabel htmlFor={name}>{`${name} (${type})`}</InputLabel>
+                    <InputWrapper key={vname} error={field.error}>
+                      <InputLabel htmlFor={vname}>{`${vname} (${type})`}</InputLabel>
                       <Input
                         onChange={this.handleParamsChange}
-                        id={name}
-                        name={name}
+                        id={vname}
+                        name={vname}
                         value={field.value}
                       />
                       {field.error && <FormHelperText>Please fill in a value</FormHelperText>}

--- a/src/browser/store/contract/saga.ts
+++ b/src/browser/store/contract/saga.ts
@@ -60,8 +60,8 @@ export function* initContract() {
 function* deployContract(action: ActionType<typeof contractActions.deploy>, db: ContractStore) {
   try {
     const { code, deployer, init: pInit, msg, gaslimit, gasprice, statusCB } = action.payload;
-    const { message: abi } = yield api.checkContract(code);
-    if (!abi) {
+    const { message: result } = yield api.checkContract(code);
+    if (!result) {
       throw new Error('ABI could not be parsed.');
     }
 
@@ -108,7 +108,7 @@ function* deployContract(action: ActionType<typeof contractActions.deploy>, db: 
     };
 
     const contract = {
-      abi: JSON.parse(abi),
+      abi: JSON.parse(result).contract_info,
       code,
       init,
       state: [{ vname: '_balance', type: 'Uint128', value: txAmount.toString() }],
@@ -213,7 +213,7 @@ function* callTransition(action: ActionType<typeof contractActions.call>, db: Co
         put(
           contractActions.addEvent(
             contractStorage.address,
-            (contractStorage.abi as ABI).name,
+            (contractStorage.abi as ABI).vname,
             event,
           ),
         ),

--- a/src/browser/store/contract/types.ts
+++ b/src/browser/store/contract/types.ts
@@ -34,12 +34,12 @@ export interface Param {
 }
 
 export interface Transition {
-  name: string;
+  vname: string;
   params: Param[];
 }
 
 export interface ABI {
-  name: string;
+  vname: string;
   fields: Param[];
   params: Param[];
   transitions: Transition[];


### PR DESCRIPTION
This fixes the reference errors caused by the change in the JSON output of `scilla-checker`. Contracts can now be deployed. Fixes #38 and #40.