### PR TITLE
Fix/checker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zilliqa/scilla:v0.2.0
+FROM 648273915458.dkr.ecr.us-west-2.amazonaws.com/scilla:latest
 
 EXPOSE 8080
 # PM2 default health check endpoint is at host:9615/

--- a/src/server/util/cmd.ts
+++ b/src/server/util/cmd.ts
@@ -118,7 +118,7 @@ export const checker = async (opts: BaseOpt) => {
 
     return stdout;
   } catch (err) {
-    throw parseCheckerError(err.stdout);
+    throw parseCheckerError(err.stderr);
   } finally {
     await cleanUp(opts);
   }


### PR DESCRIPTION
This fixes an issue caused by `scilla-checker` sometimes putting its JSON output on `stdout`, and on other occasions, `stderr`.