### PR TITLE
fix(checker): do not modify location numbers before responding

### DIFF
--- a/src/server/util/error.ts
+++ b/src/server/util/error.ts
@@ -84,8 +84,8 @@ export const parseCheckerError = (out: string): ScillaError | null => {
   return new ScillaError(
     errors.map((error: CheckerErrorObj) => {
       return {
-        line: error.start_location.line + 1,
-        column: error.start_location.column + 1,
+        line: error.start_location.line,
+        column: error.start_location.column,
         msg: error.error_message,
       };
     }),


### PR DESCRIPTION
This fix should also pull in the latest Scilla built on `master`.