### PR TITLE
feat(cmd): update checker cmd: consider gaslimit (hardcode to 80000)

### DIFF
--- a/src/server/util/cmd.ts
+++ b/src/server/util/cmd.ts
@@ -112,6 +112,8 @@ export const checker = async (opts: BaseOpt) => {
       opts.stdlib,
       '-contractinfo',
       '-cf',
+      '-gaslimit',
+      '80000',
       '-jsonerrors',
       opts.code,
     ]);


### PR DESCRIPTION
This PR updates the checker cmd so it considering the `gaslimit` option which was introduced to avoid paying linear gas for exponential computations.